### PR TITLE
chore: apply plugin version discipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
             exit 0
           fi
           "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+      - name: Verify shipped plugin.json carries tag (post-build)
+        run: "${{ runner.temp }}/wfctl-bin/wfctl plugin validate-contract --for-publish --tag ${{ github.ref_name }} --release-dir . ."
       - name: Publish GitHub release
         if: ${{ success() }}
         env:

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-broker",
-    "version": "0.2.4",
+    "version": "0.0.0",
     "author": "GoCodeAlone",
     "description": "NATS JetStream broker module for cross-instance message delivery in workflow pipelines",
     "source": "github.com/GoCodeAlone/workflow-plugin-broker",


### PR DESCRIPTION
Part of GoCodeAlone/workflow#760.\n\nChanges:\n- keep committed plugin.json.version at the 0.0.0 development sentinel\n- add post-build release validation so the shipped manifest is checked against the tag\n\nVerification:\n- wfctl plugin validate-contract .\n- wfctl plugin validate-contract --for-publish --tag v9.9.9 .\n- GOWORK=off go test ./...